### PR TITLE
fix: window has a classic-style titlebar when embed

### DIFF
--- a/native/src/win_helper.rs
+++ b/native/src/win_helper.rs
@@ -39,7 +39,11 @@ pub unsafe fn embed_into_hwnd(traywin: *const i8) {
 
     let mut lExStyle = GetWindowLongA(druidwin, GWL_EXSTYLE);
     lExStyle &= !(WS_EX_DLGMODALFRAME | WS_EX_CLIENTEDGE | WS_EX_WINDOWEDGE) as i32;
-    SetWindowLongA(druidwin, GWL_EXSTYLE, lExStyle | WS_EX_NOACTIVATE as i32);
+    SetWindowLongA(
+        druidwin,
+        GWL_EXSTYLE,
+        lExStyle | WS_EX_NOACTIVATE | WS_EX_LAYERED as i32,
+    );
     winapi::um::winuser::SetParent(druidwin, traywin as _);
 
     winapi::um::winuser::MoveWindow(


### PR DESCRIPTION
Fix the window has a unexpected Windows Classic titlebar when the window is embeded into taskbar.